### PR TITLE
Add -n argument to shim for specifying SciDB host

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ you install `shim` from a binary rpm or deb package.
 ```
 auth=login
 ports=8080,8083s
+scidbhost=localhost
 scidbport=1239 (or auto-configured by apt/yum to a local SciDB port)
 user=root
 tmp=/tmp  (or auto-configured by apt/yum to local SciDB storage directory)
@@ -86,7 +87,8 @@ The options are:
 * `auth` A PAM authentication method (limited to 'login' for now).
 * `ports` A comma-delimited list of HTTP listening ports. Append the lowercase
 letter 's' to indicate SSL encryption.
-* `scidbport` The local port to talk to SciDB on.
+* `scidbhost` The host on which SciDB runs.
+* `scidbport` The port to talk to SciDB on.
 * `user` The user that the shim service runs under. Shim can run as a non-root
 user, but then SSL authenticated port logins are limited to the user that shim
 is running under.

--- a/doc/help.Rmd
+++ b/doc/help.Rmd
@@ -65,6 +65,7 @@ Available options include:
 
 ```
 #ports=8080,8083s
+#scidbhost=localhost
 scidbport=1239
 instance=0
 tmp=/home/scidb/scidbdata/000/0/tmp
@@ -103,14 +104,22 @@ Here are some examples of possible port configurations:
 <tr><td>127.0.0.1:8080,1234s <td> <td>List on port 8080 but only on the local loopback interface; listen on port 1234(TLS/SSL) on all interfaces.
 </table>
 
-## SciDB Port
+## SciDB Connection
 
-Shim runs on the same computer as a SciDB coordinator. Set the 'scidbport'
-option to select the coordinator database port to locally connect to. The
-default SciDB database port value is 1239 (see the SciDB configuration manual
-for more information). Since any SciDB instance can act as a query coordinator,
-it is possible to configure multiple shim services, for example one shim
-service per computer IP address.
+In most of the cases, Shim runs on the same computer as a SciDB
+coordinator. Set the 'scidbport' option to select the coordinator
+database port to locally connect to. The default SciDB database port
+value is 1239 (see the SciDB configuration manual for more
+information). Since any SciDB instance can act as a query coordinator,
+it is possible to configure multiple shim services, for example one
+shim service per computer IP address.
+
+In special cases, Shim can run on a different computer that the SciDB
+coordinator. For these cases, set the `scidbhost` option to the
+hostname or IP of the computer on which the SciDB coordinator
+runs. Still, a temporary I/O space shared between the computer running
+Shim and the computer running the SciDB coordinator is needed (see
+Temporary I/O Space section below).
 
 ## Instance
 
@@ -119,7 +128,7 @@ this option is set together with the corresponding SciDB port number for the
 instance, and also set a corresponding temporary I/O location that the instance
 has read/write access to.
 
-## Temporary I/O space
+## Temporary I/O Space
 
 Shim's default behavior caches the output of SciDB queries in files on the
 SciDB server; set that file directory location with the config file tmp option

--- a/init.d/after-install.sh
+++ b/init.d/after-install.sh
@@ -28,6 +28,7 @@ cat >/var/lib/shim/conf << EOF
 # for more information on the options.
 
 #ports=8080,8083s
+#scidbhost=localhost
 scidbport=$PORT
 instance=$INS
 tmp=$TMP

--- a/init.d/shimsvc
+++ b/init.d/shimsvc
@@ -36,6 +36,7 @@ AIO=
 # This parsing is pretty lame
 if test -f "/var/lib/shim/conf"; then
   PORTS="$(cat /var/lib/shim/conf | sed -n /^ports/p | cut -d '=' -f 2)"
+  SCIDBHOST="$(cat /var/lib/shim/conf | sed -n /^scidbhost/p | cut -d '=' -f 2)"
   SCIDBPORT="$(cat /var/lib/shim/conf | sed -n /^scidbport/p | cut -d '=' -f 2)"
   USER="$(cat /var/lib/shim/conf | sed -n /^user/p | cut -d '=' -f 2)"
   TMPD="$(cat /var/lib/shim/conf | sed -n /^tmp/p | cut -d '=' -f 2)"
@@ -46,6 +47,7 @@ if test -f "/var/lib/shim/conf"; then
 # Build up shim command line options
   test -n "${PORTS}" && PORTS="-p ${PORTS}"
   test -n "${TMPD}" && TMPD="-t ${TMPD}"
+  test -n "${SCIDBHOST}" && SCIDBHOST="-n ${SCIDBHOST}"
   test -n "${SCIDBPORT}" && SCIDBPORT="-s ${SCIDBPORT}"
   test -n "${MAX_SESSIONS}" && MAX_SESSIONS="-m ${MAX_SESSIONS}"
   test -n "${TIMEOUT}" && TIMEOUT="-o ${TIMEOUT}"

--- a/src/shim.c
+++ b/src/shim.c
@@ -113,7 +113,7 @@ typedef struct
 enum mimetype
 { html, plain, binary };
 
-const char SCIDB_HOST[] = "localhost";
+char *SCIDB_HOST = "localhost";
 int SCIDB_PORT = 1239;
 session *sessions;              // Fixed pool of web client sessions
 char *docroot;
@@ -1382,9 +1382,9 @@ parse_args (char **options, int argc, char **argv, int *daemonize)
         {
         case 'h':
           printf
-            ("Usage:\nshim [-h] [-v] [-f] [-p <http port>] [-r <document root>] [-s <scidb port>] [-t <tmp I/O DIR>] [-m <max concurrent sessions] [-o http session timeout] [-i instance id for save]\n");
+            ("Usage:\nshim [-h] [-v] [-f] [-p <http port>] [-r <document root>] [-n <scidb host>] [-s <scidb port>] [-t <tmp I/O DIR>] [-m <max concurrent sessions] [-o <http session timeout>] [-i <instance id for save>]\n");
           printf
-            ("The -v option prints the version build ID and exits.\nSpecify -f to run in the foreground.\nDefault http ports are 8080 and 8083(SSL).\nDefault SciDB port is 1239.\nDefault document root is /var/lib/shim/wwwroot.\nDefault temporary I/O directory is /tmp.\nDefault max concurrent sessions is 50 (max 100).\nDefault http session timeout is 60s and min is 60 (see API doc).\nDefault instance id for save to file is 0.\n");
+            ("The -v option prints the version build ID and exits.\nSpecify -f to run in the foreground.\nDefault http ports are 8080 and 8083(SSL).\nDefault SciDB host is localhost.\nDefault SciDB port is 1239.\nDefault document root is /var/lib/shim/wwwroot.\nDefault temporary I/O directory is /tmp.\nDefault max concurrent sessions is 50 (max 100).\nDefault http session timeout is 60s and min is 60 (see API doc).\nDefault instance id for save to file is 0.\n");
           printf
             ("Start up shim and view http://localhost:8080/api.html from a browser for help with the API.\n\n");
           exit (0);
@@ -1425,6 +1425,9 @@ parse_args (char **options, int argc, char **argv, int *daemonize)
         case 'o':
           TIMEOUT = atoi (optarg);
           TIMEOUT = (TIMEOUT < 60 ? 60 : TIMEOUT);
+          break;
+        case 'n':
+          SCIDB_HOST = optarg;
           break;
         default:
           break;


### PR DESCRIPTION
Shim assumes SciDB is running on the same host and connects to SciDB using `localhost`. This patch allows the user to specify a different hostname for SciDB. `localhost` is still the default is none is specified.

One use case for this is when Shim and SciDB run in different Docker containers (having different IPs). The two containers use a volume for shared temporary I/O storage.

The changes in this patch are:

* Parse `-n` argument in shim command line for SciDB host, defaults to localhost.
* Use `scidbhost` in `conf` file and parse it in `shimsvc`
* Update README file and Help page with details on the SciDB host argument

The `-n` argument was used in the past for PAM authentication. I am reassigning it to SciDB host.