### PR TITLE
Use default gcc if version >= 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
     busybox-syslogd
     curl
     gcc
+    g++
     libarrow-dev=0.9.0-1
     libpcre3-dev
     libpqxx-dev

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,18 +33,24 @@ INC=-I. -DPROJECT_ROOT="\"$(SCIDB)\"" -I"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boo
 LIBS=-lstdc++ -ldl -lz -pthread -L"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boost/lib" -L"$(SCIDB)/lib" -lscidbclient -lboost_system -Wl,--enable-new-dtags -Wl,-rpath,'$$ORIGIN:$$ORIGIN/../lib:$$ORIGIN/../../:$(SCIDB)/3rdparty/boost/lib:'
 
 # Compiler settings for SciDB version >= 15.7
-ifneq ("$(wildcard /usr/bin/g++-4.9)","")
-  CC := "/usr/bin/gcc-4.9"
-  CXX := "/usr/bin/g++-4.9"
-  CXXFLAGS=-std=c++14
+GCCVERSIONGTE49 := $(shell expr `gcc -dumpversion | cut -f1-2 -d.` \>= 4.9)
+ifeq "$(GCCVERSIONGTE49)" "1"
+      CC := "gcc"
+      CXX := "g++"
+      CXXFLAGS=-std=c++14
 else
-  ifneq ("$(wildcard /opt/rh/devtoolset-3/root/usr/bin/gcc)","")
-    CC := "/opt/rh/devtoolset-3/root/usr/bin/gcc"
-    CXX := "/opt/rh/devtoolset-3/root/usr/bin/g++"
-    CXXFLAGS=-std=c++14
+  ifneq ("$(wildcard /usr/bin/g++-4.9)","")
+      CC := "/usr/bin/gcc-4.9"
+      CXX := "/usr/bin/g++-4.9"
+      CXXFLAGS=-std=c++14
+  else
+    ifneq ("$(wildcard /opt/rh/devtoolset-3/root/usr/bin/gcc)","")
+      CC := "/opt/rh/devtoolset-3/root/usr/bin/gcc"
+      CXX := "/opt/rh/devtoolset-3/root/usr/bin/g++"
+      CXXFLAGS=-std=c++14
+    endif
   endif
 endif
-
 # default: empty DESTDIR implicitly installs to /
 DESTDIR=
 


### PR DESCRIPTION
On ubuntu 16.04, the default /usr/bin/g{cc,++} compiler is used to
build SciDB. The c++ ABI chaged with the libstdc++ library has changed
for g++ 5.  Since SciDB uses the NEW ABI, the compilation of shim
with the older g++-4.9 is unable to use the symbols from the New ABI.
(That is, the libstdc++ is backwards compatible, but the libstdc++
used by gcc 4.9 is not forward compatible)

g++ (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.