### PR TITLE
Guarantee Query Side-Effects Complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 python:
   - "3.6"
 
-env: SCIDB_VER=19.11
+env: SCIDB_VER=19.11-centos-7
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 python:
   - "3.6"
 
-env: SCIDB_VER=19.11-centos-7
+env: SCIDB_VER=19.11
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 python:
   - "3.6"
 
-env: SCIDB_VER=19.3
+env: SCIDB_VER=19.11
 
 services:
   - docker

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -187,7 +187,7 @@ prepare_query(void *result, void *con, char *query, int afl, char *err)
  * returns a sQueryID struct with queryid set to 0.
  */
 extern "C" ShimQueryID
-execute_prepared_query(void *con, char *query, struct prep *pq, int afl, char *err)
+execute_prepared_query(void *con, char *query, struct prep *pq, int afl, char *err, int fetch)
 {
   ShimQueryID qid;
   const string &queryString = (const char *)query;
@@ -195,6 +195,7 @@ execute_prepared_query(void *con, char *query, struct prep *pq, int afl, char *e
   qid.queryid = 0;
   qid.coordinatorid = 0;
   scidb::QueryResult *q = (scidb::QueryResult *)pq->queryresult;
+  q->fetch = (fetch != 0);
   if(!q)
   {
     snprintf(err,MAX_VARLEN,"Invalid query result object.\n");

--- a/src/client.h
+++ b/src/client.h
@@ -53,7 +53,7 @@ unsigned long long executeQuery (void *con, char *query, int afl, char *err);
 
 void prepare_query (void *, void *, char *, int, char *);
 
-ShimQueryID execute_prepared_query (void *, char *, struct prep *, int, char *);
+ShimQueryID execute_prepared_query (void *, char *, struct prep *, int, char *, int);
 
 void completeQuery (ShimQueryID id, void *con, char *err);
 

--- a/tests/read.sh
+++ b/tests/read.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 ## --
 ## -- - read_* - --
 ## --
@@ -52,7 +52,7 @@ test "$res" == "200"
 res=$($CURL "$SHIM_URL/read_lines?id=$ID")
 test "$res" == "200"
 
-res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string)")
+res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string,string)")
 test "$res" == "200"
 
 res=$($CURL "$SHIM_URL/read_bytes?id=$ID")
@@ -77,7 +77,7 @@ test "$res" == "200"
 res=$($CURL "$SHIM_URL/read_lines?id=$ID")
 test "$res" == "200"
 
-res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string)")
+res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string,string)")
 test "$res" == "200"
 
 res=$($CURL "$SHIM_URL/read_bytes?id=$ID")
@@ -104,7 +104,7 @@ test "$res" == "200"
 res=$($CURL "$SHIM_URL/read_lines?id=$ID")
 test "$res" == "200"
 
-res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string)")
+res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string,string)")
 test "$res" == "200"
 res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()")
 test "$res" == "200"
@@ -137,11 +137,11 @@ test "$res" == "200"
 res=$($CURL "$SHIM_URL/read_lines?id=$ID")
 test "$res" == "200"
 
-res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string)")
+res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string,string)")
 test "$res" == "200"
 res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()")
 test "$res" == "200"
-res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string)")
+res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string,string)")
 test "$res" == "200"
 res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()")
 test "$res" == "200"
@@ -196,7 +196,7 @@ test "$res" == "$err"
 res=$($CURL "$SHIM_URL/read_lines?id=$ID")
 test "$res" == "200"
 
-res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string)")
+res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string,string)")
 test "$res" == "200"
 
 res=$($CURL "$SHIM_URL/read_bytes?id=$ID")
@@ -226,7 +226,7 @@ err="EOF - range out of bounds416"
 res=$($CURL "$SHIM_URL/read_lines?id=$ID&n=10")
 test "$res" == "$err"
 
-res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string)")
+res=$($CURL $NO_OUT "$SHIM_URL/execute_query?id=$ID&query=list()&save=(string,int64,int64,string,bool,bool,string,string,string)")
 test "$res" == "200"
 err="EOF - range out of bounds416"
 


### PR DESCRIPTION
Before this change, and in the case that the client ignores
the query result (either by supplying '-n' with iquery or not pulling
the result array here in the shim) then any side-effects of query execution
are not guaranteed to occur.  For example, a query like 'apply(arr, x, func(v))'
that is executed but not pulled by the client will not guarantee that
function 'func' is applied to every v in arr.
This change, and the corresponding change in SciDB, is a temporary
workaround until CCM roll-out occurs, whereby a consume() is injected
at the root of the query when the client indicates that they will not
pull the query result.  In that case, consume() acts to pull the result
array on every instance, therby ensuring side-effects occur just as they
would had the client pulled the result array.

Fixes read.sh test script to accomodate list() output format change.