### PR TITLE
CXXFLAGS clean-up

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,26 +33,22 @@ INC=-I. -DPROJECT_ROOT="\"$(SCIDB)\"" -I"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boo
 LIBS=-lstdc++ -ldl -lz -pthread -L"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boost/lib" -L"$(SCIDB)/lib" -lscidbclient -lboost_system -Wl,--enable-new-dtags -Wl,-rpath,'$$ORIGIN:$$ORIGIN/../lib:$$ORIGIN/../../:$(SCIDB)/3rdparty/boost/lib:'
 
 # Compiler settings for SciDB version >= 15.7
+CXXFLAGS=-std=c++14
 GCCVERSIONGTE49 := $(shell expr `gcc -dumpversion | cut -f1-2 -d.` \>= 4.9)
 ifeq "$(GCCVERSIONGTE49)" "1"
       CC := "gcc"
       CXX := "g++"
-      CXXFLAGS=-std=c++14
 else
   ifneq ("$(wildcard /usr/bin/g++-4.9)","")
       CC := "/usr/bin/gcc-4.9"
       CXX := "/usr/bin/g++-4.9"
-      CXXFLAGS=-std=c++14
   else
     ifneq ("$(wildcard /opt/rh/devtoolset-3/root/usr/bin/gcc)","")
       CC := "/opt/rh/devtoolset-3/root/usr/bin/gcc"
       CXX := "/opt/rh/devtoolset-3/root/usr/bin/g++"
-      CXXFLAGS=-std=c++14
     endif
   endif
 endif
-
-CXXFLAGS=-std=c++11 -std=gnu++14
 
 # default: empty DESTDIR implicitly installs to /
 DESTDIR=


### PR DESCRIPTION
I did a brief clean-up on the `CXXFLAGS` parameter in the `Makefile` in order to avoid duplication and unnecessary overwrites. @JAKinchen let me know if this make sense. Next step is to merge this into the main `v19.11` branch.