### PR TITLE
Shim no longer completes an auto-commit query

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -55,6 +55,6 @@ void prepare_query (void *, void *, char *, int, char *);
 
 ShimQueryID execute_prepared_query (void *, char *, struct prep *, int, char *, int);
 
-void completeQuery (ShimQueryID id, void *con, char *err);
+void completeQuery (struct prep* pq, void *con, char *err);
 
 #endif /* SRC_CLIENT_H_ */

--- a/src/shim.c
+++ b/src/shim.c
@@ -1800,7 +1800,7 @@ execute_query (struct mg_connection *conn, const struct mg_request_info *ri)
             }
            if (s->scidb[0])
              {
-               completeQuery (q, s->scidb[0], SERR);
+               completeQuery (&pq, s->scidb[0], SERR);
              }
            qstart = qend + 1;
          }
@@ -1865,7 +1865,7 @@ execute_query (struct mg_connection *conn, const struct mg_request_info *ri)
     }
   if (s->scidb[0])
     {
-      completeQuery (q, s->scidb[0], SERR);
+      completeQuery (&pq, s->scidb[0], SERR);
     }
 
   free (qry);


### PR DESCRIPTION
Clients shouldn't ask SciDB to complete a query that is marked
auto-commit.  Certain DDL, like create_array queries, auto-commit
by design.

Tested for memory leaks with 'valgrind --leak-check=full' while
running the script found here:
https://github.com/rvernica/docker-library/issues/12#issuecomment-652387862