### PR TITLE
Flag to allow for systemctl failures during installation

### DIFF
--- a/init.d/after-install.sh
+++ b/init.d/after-install.sh
@@ -6,22 +6,29 @@
 
 /opt/scidb/XXX_SCIDB_VER_XXX/shim/setup-conf.sh
 
-if test -n "$(which systemctl 2>/dev/null)"; then
-# SystemD
-  cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.service /lib/systemd/system/shimsvc.service
-  systemctl daemon-reload
-  systemctl enable shimsvc
-  systemctl start shimsvc
-elif test -n "$(which update-rc.d 2>/dev/null)"; then
-# Ubuntu
-  cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
-  chmod 0755 /etc/init.d/shimsvc
-  update-rc.d shimsvc defaults
-  service shimsvc start
-elif test -n "$(which chkconfig 2>/dev/null)"; then
-# RHEL sysV
-  cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
-  chmod 0755 /etc/init.d/shimsvc
-  chkconfig --add shimsvc && chkconfig shimsvc on
-  service shimsvc start
+if [ "$SKIP_SHIM_SERVICE" != "true" ]
+then
+    if test -n "$(which systemctl 2>/dev/null)"
+    then
+        # SystemD
+        cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.service \
+           /lib/systemd/system/shimsvc.service
+        systemctl daemon-reload
+        systemctl enable shimsvc
+        systemctl start shimsvc
+    elif test -n "$(which update-rc.d 2>/dev/null)"
+    then
+        # Ubuntu
+        cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
+        chmod 0755 /etc/init.d/shimsvc
+        update-rc.d shimsvc defaults
+        service shimsvc start
+    elif test -n "$(which chkconfig 2>/dev/null)"
+    then
+        # RHEL sysV
+        cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
+        chmod 0755 /etc/init.d/shimsvc
+        chkconfig --add shimsvc && chkconfig shimsvc on
+        service shimsvc start
+    fi
 fi

--- a/init.d/after-install.sh
+++ b/init.d/after-install.sh
@@ -6,29 +6,28 @@
 
 /opt/scidb/XXX_SCIDB_VER_XXX/shim/setup-conf.sh
 
-if [ "$SKIP_SHIM_SERVICE" != "true" ]
+if test -n "$(which systemctl 2>/dev/null)"
 then
-    if test -n "$(which systemctl 2>/dev/null)"
-    then
-        # SystemD
-        cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.service \
-           /lib/systemd/system/shimsvc.service
-        systemctl daemon-reload
-        systemctl enable shimsvc
-        systemctl start shimsvc
-    elif test -n "$(which update-rc.d 2>/dev/null)"
-    then
-        # Ubuntu
-        cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
-        chmod 0755 /etc/init.d/shimsvc
-        update-rc.d shimsvc defaults
-        service shimsvc start
-    elif test -n "$(which chkconfig 2>/dev/null)"
-    then
-        # RHEL sysV
-        cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
-        chmod 0755 /etc/init.d/shimsvc
-        chkconfig --add shimsvc && chkconfig shimsvc on
-        service shimsvc start
-    fi
+    # SystemD
+    cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.service \
+       /lib/systemd/system/shimsvc.service
+    systemctl daemon-reload                                     \
+        || test "$EXTRA_SCIDB_LIBS_SYSTEMCTL_FAIL_OK" == "true"
+    systemctl enable shimsvc
+    systemctl start shimsvc                                     \
+        || test "$EXTRA_SCIDB_LIBS_SYSTEMCTL_FAIL_OK" == "true"
+elif test -n "$(which update-rc.d 2>/dev/null)"
+then
+    # Ubuntu
+    cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
+    chmod 0755 /etc/init.d/shimsvc
+    update-rc.d shimsvc defaults
+    service shimsvc start
+elif test -n "$(which chkconfig 2>/dev/null)"
+then
+    # RHEL sysV
+    cp /opt/scidb/XXX_SCIDB_VER_XXX/shim/shimsvc.initd /etc/init.d/shimsvc
+    chmod 0755 /etc/init.d/shimsvc
+    chkconfig --add shimsvc && chkconfig shimsvc on
+    service shimsvc start
 fi


### PR DESCRIPTION
When `extra-scidb-libs` package is installed, as a post-install step the `after-install.sh` script is executed. This script setups up the Shim service. Currently `extra-scidb-libs` cannot be installed while building Docker containers since SystemD is not functional. 

This patch allows for errors to occur during `systemctl` commands if the environment variable `EXTRA_SCIDB_LIBS_SYSTEMCTL_FAIL_OK` is set to `true`.

The changes are in lines 14:15 and 17:18 in the new version.